### PR TITLE
Add KSgeneral

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -56,6 +56,10 @@
         "url": "https://github.com/ThierryO/kableExtra"
     },
     {
+        "package": "KSgeneral",
+        "url": "https://github.com/raymondtsr/ksgeneral"
+    },
+    {
         "package": "ladybird",
         "url": "https://github.com/inbo/ladybird"
     },


### PR DESCRIPTION
A quick-fix to make the **watina** package installable again using `install.packages()`; it uses **KSgeneral** but the latter has been removed from CRAN in February and has not been substantially maintained after 2018.

Some envisaged fixes in **watina** for this are:

- short term: move **KSgeneral** to Suggests, only load package when needed
- long-term: consider an alternative (or have a look what it would take to get it on CRAN again)

Related issues: https://github.com/raymondtsr/ksgeneral/issues/5, https://github.com/inbo/watina/issues/93