### PR TITLE
Drop KSgeneral

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -60,10 +60,6 @@
         "url": "https://github.com/ThierryO/kableExtra"
     },
     {
-        "package": "KSgeneral",
-        "url": "https://github.com/raymondtsr/ksgeneral"
-    },
-    {
         "package": "ladybird",
         "url": "https://github.com/inbo/ladybird"
     },


### PR DESCRIPTION
Build fails here, won't fix it, and it's back on CRAN anyway. Next occasion of CRAN inavailability will be solved by stopping to use it directly.